### PR TITLE
Add ability to disable time limits per-class or per-method level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed correct line number rendering in Github Actions ([\#3](https://github.com/NexusPHP/tachycardia/pull/3))
 - Fixed initial release date ([\#4](https://github.com/NexusPHP/tachycardia/pull/4))
 - Added ability to supply class-level time limit annotations ([\#5](https://github.com/NexusPHP/tachycardia/pull/5))
+- Added ability to disable time limits on a per-class or per-method level ([\#6](https://github.com/NexusPHP/tachycardia/pull/6))
 
 ## [v1.0.0](https://github.com/NexusPHP/tachycardia/releases/tag/v1.0.0) - 2021-03-21
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ during pull requests.
 **NOTE:** Tachycardia will only detect the slow tests in your test suites but will offer no explanation
 as to why these identified are slow. You should use a dedicated profiler for these instead.
 
-```sh
+```console
 $ vendor/bin/phpunit
 PHPUnit 9.5.3 by Sebastian Bergmann and contributors.
 
@@ -195,6 +195,15 @@ Add the `env` element to your `phpunit.xml.dist` file disabling Tachycardia then
     TACHYCARDIA_MONITOR: disabled
 ```
 
+### Enable/disable profiling in Github Actions
+
+Profiling in development for the Github Actions is **disabled** by default because the console cannot
+interpret the special workflow commands used by Github Actions. Using the `TACHYCARDIA_MONITOR_GA`
+variable, you can enable it by exporting `TACHYCARDIA_MONITOR_GA=enabled`. To disable, just export
+`TACHYCARDIA_MONITOR_GA=disabled`.
+
+The steps here are similar to above procedures for setting `TACHYCARDIA_MONITOR` variable.
+
 #### 3. Disable profiling and enable only on demand
 
 ```xml
@@ -215,7 +224,7 @@ Add the `env` element to your `phpunit.xml.dist` file disabling Tachycardia then
 When running `vendor/bin/phpunit` either from the terminal or from Github Actions, just pass the variable
 like this:
 
-```sh
+```console
 $ TACHYCARDIA_MONITOR=enabled vendor/bin/phpunit
 ```
 
@@ -263,14 +272,36 @@ annotation will take precedence.
 
 The order of precedence is: `method-level annotation > class-level annotation > default time limit`
 
-### Enable/disable profiling in Github Actions
+### Disabling time limits per test or per class
 
-Profiling in development for the Github Actions is **disabled** by default because the console cannot
-interpret the special workflow commands used by Github Actions. Using the `TACHYCARDIA_MONITOR_GA`
-variable, you can enable it by exporting `TACHYCARDIA_MONITOR_GA=enabled`. To disable, just export
-`TACHYCARDIA_MONITOR_GA=disabled`.
+There may be instances where you do not want to include a particular test case or class from slow test
+profiling. One reason is that you do not want to be burdened first of the existing slow tests and just fix
+"for now" the emerging slow tests. Whatever reason that may be, you can disable the profiling by using
+the `@noTimeLimit` annotation. This can be placed either in the test case or in the test class.
 
-The steps here are similar to above procedures for setting `TACHYCARDIA_MONITOR` variable.
+```php
+// method-level disabling
+final class FooTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @noTimeLimit
+     */
+    public function testExtremelySlowTest(): void {}
+}
+
+// class-level disabling
+/**
+ * @noTimeLimit
+ */
+final class BarTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSluggishTest(): void {}
+}
+```
+
+Method-level disabling takes precedence from class-level disabling. Moreover, if you have a `@noTimeLimit`
+applied to a test case, either through the method or the class, and a custom `@timeLimit` applied also to
+this test case, **THE `@noTimeLIMIT` ANNOTATION WILL TAKE PRECEDENCE**.
 
 ### Tabulating results instead of plain render
 
@@ -298,7 +329,7 @@ in the `phpunit.xml.dist` file.
 
 Running `vendor/bin/phpunit` will now yield the report similar to this:
 
-```sh
+```console
 $ vendor/bin/phpunit
 PHPUnit 9.5.3 by Sebastian Bergmann and contributors.
 

--- a/src/Tachycardia.php
+++ b/src/Tachycardia.php
@@ -120,7 +120,7 @@ final class Tachycardia implements AfterLastTestHook, AfterSuccessfulTestHook, B
         $label = $this->getTestName($test);
         $limit = $this->parseTimeLimit($test);
 
-        if ($time >= $limit) {
+        if (! $this->isProfilingDisabled($test) && $time >= $limit) {
             $this->slowTests[] = compact('label', 'time', 'limit');
         }
     }
@@ -365,6 +365,25 @@ final class Tachycardia implements AfterLastTestHook, AfterSuccessfulTestHook, B
         }
 
         return $this->timeLimit;
+    }
+
+    /**
+     * Whether a test case is disabled for profiling, i.e., to
+     * be skipped for analysis.
+     *
+     * Order of precedence
+     * - method @noTimeLimit
+     * - class @noTimeLimit
+     *
+     * @param string $test
+     *
+     * @return bool
+     */
+    private function isProfilingDisabled(string $test): bool
+    {
+        $annotations = $this->getAnnotations($test);
+
+        return isset($annotations['method']['noTimeLimit'][0]) || isset($annotations['class']['noTimeLimit'][0]);
     }
 
     private function color(string $text, string $color): string

--- a/tests/NoTimeLimitInClassTest.php
+++ b/tests/NoTimeLimitInClassTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of NexusPHP Tachycardia.
+ *
+ * (c) 2021 John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Nexus\PHPUnit\Extension\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @noTimeLimit
+ *
+ * @internal
+ */
+final class NoTimeLimitInClassTest extends TestCase
+{
+    /**
+     * This should not be reported as slow since
+     * this is explicitly disabled.
+     *
+     * @return void
+     */
+    public function testSlowTestDisabledForProfiling(): void
+    {
+        usleep(1500000);
+        self::assertTrue(true);
+    }
+}

--- a/tests/NoTimeLimitInMethodTest.php
+++ b/tests/NoTimeLimitInMethodTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of NexusPHP Tachycardia.
+ *
+ * (c) 2021 John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Nexus\PHPUnit\Extension\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class NoTimeLimitInMethodTest extends TestCase
+{
+    /**
+     * This should be reported as slow.
+     *
+     * @return void
+     */
+    public function testSlowTestNotDisabled(): void
+    {
+        usleep(1500000);
+        self::assertTrue(true);
+    }
+
+    /**
+     * This should not be reported as slow since
+     * this is explicitly disabled.
+     *
+     * @noTimeLimit
+     *
+     * @return void
+     */
+    public function testSlowTestDisabledForProfiling(): void
+    {
+        usleep(1500000);
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Description

This PR adds the ability to disable time limits for specific tests or test classes by using the `@noTimeLimit` annotation.

## Type of Change <!-- Delete the options which are irrelevant -->
- [x] New feature but is fully backwards compatible. Closes #2 

## Checklist
- [x] All commits are GPG-signed
- [x] Code adheres strictly to coding standards of the library
- [x] Tests were added to fixes or new features
