### PR TITLE
`Expeditable` trait - introduction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
+        "phpunit/php-timer": "^5.0",
         "phpunit/phpunit": "^9.5"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -37,13 +37,16 @@
                         <double>1.00</double>
                     </element>
                     <element key="reportable">
-                        <integer>20</integer>
+                        <integer>30</integer>
                     </element>
                     <element key="precision">
                         <integer>4</integer>
                     </element>
                     <element key="tabulate">
                         <boolean>false</boolean>
+                    </element>
+                    <element key="collectBare">
+                        <boolean>true</boolean>
                     </element>
                 </array>
             </arguments>

--- a/src/Expeditable.php
+++ b/src/Expeditable.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of NexusPHP Tachycardia.
+ *
+ * (c) 2021 John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Nexus\PHPUnit\Extension;
+
+use Nexus\PHPUnit\Extension\Util\Parser;
+use PHPUnit\Util\Test as TestUtil;
+use SebastianBergmann\Timer\Timer;
+
+/**
+ * The trait is used to hook into `PHPUnit\Framework\TestCase`'s
+ * `runTest` method to obtain a streamlined benchmarking of its
+ * execution time.
+ */
+trait Expeditable
+{
+    /**
+     * Overridden to run the test and assert its executed time state.
+     *
+     * @throws \SebastianBergmann\ObjectEnumerator\InvalidArgumentException
+     * @throws \PHPUnit\Framework\AssertionFailedError
+     * @throws \PHPUnit\Framework\Exception
+     * @throws \PHPUnit\Framework\ExpectationFailedException
+     * @throws \Throwable
+     *
+     * @return mixed
+     */
+    protected function runTest()
+    {
+        $timer = new Timer();
+        $timer->start();
+
+        $result = parent::runTest();
+        $time = $timer->stop()->asSeconds();
+
+        $this->store($time);
+
+        return $result;
+    }
+
+    /**
+     * Stores the "slim" execution time of the test case into
+     * the global `$__TACHYCARDIA_TIME_STATES` array.
+     *
+     * @param float $time
+     *
+     * @return void
+     */
+    private function store(float $time): void
+    {
+        $testName = TestUtil::describeAsString($this);
+        $testName = Parser::getInstance()->parseTest($testName)->getTestName();
+        $testName = md5($testName);
+
+        if (! isset($GLOBALS['__TACHYCARDIA_TIME_STATES'][$testName])) {
+            $GLOBALS['__TACHYCARDIA_TIME_STATES'][$testName] = [];
+        }
+
+        $GLOBALS['__TACHYCARDIA_TIME_STATES'][$testName]['bare'] = $time;
+    }
+}

--- a/src/ExpeditableTestCase.php
+++ b/src/ExpeditableTestCase.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of NexusPHP Tachycardia.
+ *
+ * (c) 2021 John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Nexus\PHPUnit\Extension;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * An extension to TestCase using the Expeditable trait.
+ * Used mainly in conjunction with `collectBare` option
+ * on Tachycardia.
+ */
+abstract class ExpeditableTestCase extends TestCase
+{
+    use Expeditable;
+}

--- a/src/Util/TimeState.php
+++ b/src/Util/TimeState.php
@@ -29,9 +29,7 @@ final class TimeState
     public function __construct(array $timeStates = [])
     {
         if ([] === $timeStates) {
-            if (! isset($GLOBALS['__TACHYCARDIA_TIME_STATES'])) {
-                $GLOBALS['__TACHYCARDIA_TIME_STATES'] = [];
-            }
+            $GLOBALS['__TACHYCARDIA_TIME_STATES'] = $GLOBALS['__TACHYCARDIA_TIME_STATES'] ?? [];
 
             $this->timeStates = &$GLOBALS['__TACHYCARDIA_TIME_STATES'];
 

--- a/src/Util/TimeState.php
+++ b/src/Util/TimeState.php
@@ -21,9 +21,6 @@ final class TimeState
     /** @var array<string, array<string, float>> */
     private $timeStates = [];
 
-    /** @var Parser */
-    private $parser;
-
     /**
      * Constructor.
      *
@@ -37,12 +34,16 @@ final class TimeState
             if (! \is_array($timeStates)) {
                 $timeStates = [];
             }
-
-            unset($GLOBALS['__TACHYCARDIA_TIME_STATES']);
         }
 
-        $this->timeStates = $timeStates;
-        $this->parser = Parser::getInstance();
+        $this->timeStates = &$timeStates;
+    }
+
+    public function __destruct()
+    {
+        if (isset($GLOBALS['__TACHYCARDIA_TIME_STATES'])) {
+            unset($GLOBALS['__TACHYCARDIA_TIME_STATES']);
+        }
     }
 
     /**
@@ -67,7 +68,7 @@ final class TimeState
      */
     public function find(string $test, ?float $actual = null)
     {
-        $testName = $this->parser->parseTest($test)->getTestName();
+        $testName = Parser::getInstance()->parseTest($test)->getTestName();
         $testName = md5($testName);
 
         if (null !== $actual) {

--- a/src/Util/TimeState.php
+++ b/src/Util/TimeState.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of NexusPHP Tachycardia.
+ *
+ * (c) 2021 John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Nexus\PHPUnit\Extension\Util;
+
+/**
+ * @internal
+ */
+final class TimeState
+{
+    /** @var array<string, array<string, float>> */
+    private $timeStates = [];
+
+    /** @var Parser */
+    private $parser;
+
+    /**
+     * Constructor.
+     *
+     * @param array<string, array<string, float>> $timeStates
+     */
+    public function __construct(array $timeStates = [])
+    {
+        if ([] === $timeStates && isset($GLOBALS['__TACHYCARDIA_TIME_STATES'])) {
+            $timeStates = $GLOBALS['__TACHYCARDIA_TIME_STATES'];
+
+            if (! \is_array($timeStates)) {
+                $timeStates = [];
+            }
+
+            unset($GLOBALS['__TACHYCARDIA_TIME_STATES']);
+        }
+
+        $this->timeStates = $timeStates;
+        $this->parser = Parser::getInstance();
+    }
+
+    /**
+     * Retrieve all time states.
+     *
+     * @return array<string, array<string, float>>
+     */
+    public function retrieve(): array
+    {
+        return $this->timeStates;
+    }
+
+    /**
+     * Finds the bare time for the test, with default to `$actual` if not set.
+     * If `$test` is not set, null is returned. If `$actual` is null, returns the
+     * array of times for the test, which includes the actual and bare times.
+     *
+     * @param string     $test
+     * @param null|float $actual
+     *
+     * @return null|array<string, float>|float
+     */
+    public function find(string $test, ?float $actual = null)
+    {
+        $testName = $this->parser->parseTest($test)->getTestName();
+        $testName = md5($testName);
+
+        if (null !== $actual) {
+            if (isset($this->timeStates[$testName]) && ! isset($this->timeStates[$testName]['actual'])) {
+                $this->timeStates[$testName]['actual'] = $actual;
+            }
+        }
+
+        $result = $this->timeStates[$testName] ?? null;
+
+        if (null === $result || null === $actual) {
+            return $result;
+        }
+
+        return $result['bare'] ?? $actual;
+    }
+}

--- a/src/Util/TimeState.php
+++ b/src/Util/TimeState.php
@@ -28,15 +28,17 @@ final class TimeState
      */
     public function __construct(array $timeStates = [])
     {
-        if ([] === $timeStates && isset($GLOBALS['__TACHYCARDIA_TIME_STATES'])) {
-            $timeStates = $GLOBALS['__TACHYCARDIA_TIME_STATES'];
-
-            if (! \is_array($timeStates)) {
-                $timeStates = [];
+        if ([] === $timeStates) {
+            if (! isset($GLOBALS['__TACHYCARDIA_TIME_STATES'])) {
+                $GLOBALS['__TACHYCARDIA_TIME_STATES'] = [];
             }
+
+            $this->timeStates = &$GLOBALS['__TACHYCARDIA_TIME_STATES'];
+
+            return;
         }
 
-        $this->timeStates = &$timeStates;
+        $this->timeStates = $timeStates;
     }
 
     public function __destruct()
@@ -58,8 +60,9 @@ final class TimeState
 
     /**
      * Finds the bare time for the test, with default to `$actual` if not set.
-     * If `$test` is not set, null is returned. If `$actual` is null, returns the
-     * array of times for the test, which includes the actual and bare times.
+     * If `$test` is not set, `$actual` is returned, which can be null or float.
+     * If `$actual` is null, returns the array of times for the test, which
+     * includes the actual and bare times.
      *
      * @param string     $test
      * @param null|float $actual
@@ -79,7 +82,11 @@ final class TimeState
 
         $result = $this->timeStates[$testName] ?? null;
 
-        if (null === $result || null === $actual) {
+        if (null === $result) {
+            return $actual;
+        }
+
+        if (null === $actual) {
             return $result;
         }
 

--- a/tests/ExpeditableTest.php
+++ b/tests/ExpeditableTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of NexusPHP Tachycardia.
+ *
+ * (c) 2021 John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Nexus\PHPUnit\Extension\Tests;
+
+use Nexus\PHPUnit\Extension\Expeditable;
+use PHPUnit\Framework\Constraint\IsType;
+use PHPUnit\Framework\Constraint\LessThan;
+use PHPUnit\Framework\Constraint\LogicalAnd;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class ExpeditableTest extends TestCase
+{
+    use Expeditable;
+
+    protected function setUp(): void
+    {
+        sleep(1);
+    }
+
+    protected function tearDown(): void
+    {
+        sleep(1);
+    }
+
+    public function testFastTest(): void
+    {
+        self::assertTrue(true);
+    }
+
+    /**
+     * @depends testFastTest
+     *
+     * @return void
+     */
+    public function testTraitEliminatesHookTimes(): void
+    {
+        $testName = md5('Nexus\PHPUnit\Extension\Tests\ExpeditableTest::testFastTest');
+        self::assertTrue(isset($GLOBALS['__TACHYCARDIA_TIME_STATES'][$testName]));
+        self::assertTrue(isset($GLOBALS['__TACHYCARDIA_TIME_STATES'][$testName]['bare']));
+        self::assertThat(
+            $GLOBALS['__TACHYCARDIA_TIME_STATES'][$testName]['bare'],
+            LogicalAnd::fromConstraints(new IsType('float'), new LessThan(1.0))
+        );
+    }
+}

--- a/tests/Live/ExpeditedTimeTest.php
+++ b/tests/Live/ExpeditedTimeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of NexusPHP Tachycardia.
+ *
+ * (c) 2021 John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Nexus\PHPUnit\Extension\Tests\Live;
+
+use Nexus\PHPUnit\Extension\ExpeditableTestCase;
+
+/**
+ * @internal
+ */
+final class ExpeditedTimeTest extends ExpeditableTestCase
+{
+    protected function setUp(): void
+    {
+        sleep(1);
+    }
+
+    public function testExpeditedTestButHookIsSlowIsNotReportedAsSlow(): void
+    {
+        self::assertTrue(true);
+    }
+}

--- a/tests/TachycardiaTest.php
+++ b/tests/TachycardiaTest.php
@@ -64,7 +64,7 @@ final class TachycardiaTest extends TestCase
         $tachycardia = new Tachycardia(['reportable' => 1]);
         $tachycardia->executeBeforeFirstTest();
         $tachycardia->executeAfterSuccessfulTest(__METHOD__, 2.5);
-        $tachycardia->executeAfterSuccessfulTest(__CLASS__ . '::testSlowTest', 2);
+        $tachycardia->executeAfterSuccessfulTest(SlowTestsTest::class . '::testSlowTest', 2);
 
         ob_start();
         $tachycardia->executeAfterLastTest();
@@ -76,10 +76,10 @@ final class TachycardiaTest extends TestCase
 
     public function testWithTabulate(): void
     {
-        $tachycardia = new Tachycardia(['tabulate' => true]);
+        $tachycardia = new Tachycardia(['tabulate' => true, 'collectBare' => true]);
         $tachycardia->executeBeforeFirstTest();
         $tachycardia->executeAfterSuccessfulTest(__METHOD__, 2.5);
-        $tachycardia->executeAfterSuccessfulTest(__CLASS__ . '::testSlowestTest', 7225);
+        $tachycardia->executeAfterSuccessfulTest(SlowTestsTest::class . '::testSlowestTest', 7225);
 
         ob_start();
         $tachycardia->executeAfterLastTest();

--- a/tests/Util/TimeStateTest.php
+++ b/tests/Util/TimeStateTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of NexusPHP Tachycardia.
+ *
+ * (c) 2021 John Paul E. Balandan, CPA <paulbalandan@gmail.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Nexus\PHPUnit\Extension\Tests\Util;
+
+use Nexus\PHPUnit\Extension\Tests\Live\SlowTestsTest;
+use Nexus\PHPUnit\Extension\Util\TimeState;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class TimeStateTest extends TestCase
+{
+    /** @var string */
+    private $test1;
+
+    /** @var string */
+    private $test2;
+
+    /** @var string */
+    private $test3;
+
+    /** @var string */
+    private $test4;
+
+    /** @var array<string, array<string, float>> */
+    private $states;
+
+    protected function setUp(): void
+    {
+        $this->test1 = sprintf('%s::%s', SlowTestsTest::class, 'testFastTest');
+        $this->test2 = sprintf('%s::%s', SlowTestsTest::class, 'testWithProvider with data set "slow"');
+        $this->test3 = sprintf('%s::%s', SlowTestsTest::class, 'testWithProvider with data set "slower"');
+        $this->test4 = sprintf('%s::%s', SlowTestsTest::class, 'testWithProvider with data set "slowest"');
+
+        $this->states = $GLOBALS['__TACHYCARDIA_TIME_STATES'] = [
+            md5($this->test1) => ['bare' => 0.5],
+            md5($this->test2) => ['bare' => 5.0],
+            md5($this->test3) => [],
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($GLOBALS['__TACHYCARDIA_TIME_STATES'])) {
+            unset($GLOBALS['__TACHYCARDIA_TIME_STATES']);
+        }
+    }
+
+    public function testTimeStateAcceptsNonEmptyArrayAsIs(): void
+    {
+        $array = [$this->test1 => ['bare' => 1.0]];
+        $timeState = new TimeState($array);
+
+        self::assertInstanceOf(TimeState::class, $timeState);
+        self::assertSame($array, $timeState->retrieve());
+    }
+
+    public function testEmptyArrayParamGivesGlobals(): void
+    {
+        $timeState = new TimeState();
+        self::assertSame($this->states, $timeState->retrieve());
+    }
+
+    public function testNonEmptyGlobalsDefaultsToArray(): void
+    {
+        $GLOBALS['__TACHYCARDIA_TIME_STATES'] = false;
+        $timeState = new TimeState();
+        self::assertSame([], $timeState->retrieve());
+    }
+
+    public function testFindUnknownTest(): void
+    {
+        self::assertNull((new TimeState())->find($this->test4));
+    }
+
+    public function testFindLoggedTests(): void
+    {
+        $timeState = new TimeState();
+
+        self::assertSame(0.5, $timeState->find($this->test1, 1.0));
+        self::assertIsArray($timeState->find($this->test1));
+        self::assertSame(5.0, $timeState->find($this->test2 . ' (', 1.0));
+        self::assertIsArray($timeState->find($this->test2 . ' ('));
+        self::assertSame(1.0, $timeState->find($this->test3 . ' (', 1.0));
+        self::assertSame(['actual' => 1.0], $timeState->find($this->test3 . ' ('));
+    }
+}

--- a/tests/Util/TimeStateTest.php
+++ b/tests/Util/TimeStateTest.php
@@ -54,7 +54,7 @@ final class TimeStateTest extends TestCase
         $this->test3 = sprintf('%s::%s', SlowTestsTest::class, 'testWithProvider with data set "slower"');
         $this->test4 = sprintf('%s::%s', SlowTestsTest::class, 'testWithProvider with data set "slowest"');
 
-        $this->oldStates = $GLOBALS['__TACHYCARDIA_TIME_STATES'];
+        $this->oldStates = $GLOBALS['__TACHYCARDIA_TIME_STATES'] ?? [];
 
         $this->states = $GLOBALS['__TACHYCARDIA_TIME_STATES'] = [
             md5($this->test1) => ['bare' => 0.5],


### PR DESCRIPTION
## Description

This PR introduces the `Nexus\PHPUnit\Extension\Expeditable` trait which can be used in users' test cases so that the reported PHPUnit's test execution times are bypassed and the bare minimum times are instead reported. Alternatively, instead of inserting the trait in each test case, this also provides the abstract class `ExpeditableTestCase` to be used in lieu of the regular PHPUnit `TestCase`.
```php
// using the trait
final class FooTest extends \PHPUnit\Framework\TestCase
{
    use \Nexus\PHPUnit\Extension\Expeditable;

    // ..
}

// using the abstract class
final class FooTest extends \Nexus\PHPUnit\Extension\ExpeditableTestCase
{
    // ..
}
```

The trait (or the abstract class) will separately record the actual time spent by the tests _sans_ the hook methods (i.e., `setUp`, `tearDown`, `setUpBeforeClass`, etc.). To make this feature actually work, this PR adds a new configuration option, a boolean  `$collectBare`, which tells Tachycardia to listen for the "bare" times reported by the `Expeditable` trait. This defaults to `false`.
```xml
<?xml version="1.0" encoding="UTF-8"?>
<phpunit bootstrap="vendor/autoload.php">
...
    <extensions>
        <extension class="Nexus\PHPUnit\Extension\Tachycardia">
            <arguments>
                <array>
                    ...
                    <element key="collectBare">
                        <boolean>true</boolean>
                    </element>
                </array>
            </arguments>
        </extension>
    </extensions>
</phpunit>
```

## Type of Change <!-- Delete the options which are irrelevant -->
- [x] New feature but is fully backwards compatible. Closes #8 

## Checklist
- [x] All commits are GPG-signed
- [x] Code adheres strictly to coding standards of the library
- [x] Tests were added to fixes or new features
- [ ] Documentation updates